### PR TITLE
Use an analyzer to detect blacklisted APIs

### DIFF
--- a/CSDiscordFunction/CSDiscordFunction.csproj
+++ b/CSDiscordFunction/CSDiscordFunction.csproj
@@ -246,6 +246,7 @@
     <Content Include="app.config" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="EvalTrigger\BlacklistedTypesAnalyzer.cs" />
     <Compile Include="EvalTrigger\EvalFunction.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/CSDiscordFunction/EvalTrigger/BlacklistedTypesAnalyzer.cs
+++ b/CSDiscordFunction/EvalTrigger/BlacklistedTypesAnalyzer.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace CSDiscordFunction
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class BlacklistedTypesAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "MOD0001";
+        private static readonly LocalizableString Title = "Prohibited API";
+        private static readonly LocalizableString MessageFormat = "Usage of this API is prohibited";
+        private const string Category = "Discord";
+
+        internal static DiagnosticDescriptor Rule =
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Error, true);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+            ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterSemanticModelAction(AnalyzeSymbol);
+        }
+
+        private static void AnalyzeSymbol(SemanticModelAnalysisContext context)
+        {
+            var model = context.SemanticModel;
+
+            var tree = model.SyntaxTree;
+            var nodes = tree.GetRoot()
+                .DescendantNodes(n => true)
+                .Where(n => n is IdentifierNameSyntax || n is ExpressionSyntax);
+
+            foreach (var node in nodes)
+            {
+                var symbol = node is IdentifierNameSyntax
+                    ? model.GetSymbolInfo(node).Symbol
+                    : model.GetTypeInfo(node).Type;
+
+                if (symbol is INamedTypeSymbol namedSymbol &&
+                    namedSymbol.Name == typeof(Environment).Name)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(Rule, node.GetLocation()));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This introduces `BlacklistedTypesAnalyzer` to detects references to specific APIs in the framework. Currently it only detects references to `System.Environment`, but that can be changed. I'm not sure if you have an easy way to test these changes or not, and I didn't feel comfortable adding new projects to the solution, so I did not include tests in this PR.