### PR TITLE
DisassemblyService should compile in Release mode

### DIFF
--- a/CSDiscordService/Eval/DisassemblyService.cs
+++ b/CSDiscordService/Eval/DisassemblyService.cs
@@ -75,7 +75,7 @@ namespace CSDiscordService.Eval
             var opts = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest).WithKind(SourceCodeKind.Regular);
 
             var scriptSyntaxTree = CSharpSyntaxTree.ParseText(toExecute, opts);
-            var compOpts = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary).WithOptimizationLevel(OptimizationLevel.Debug).WithAllowUnsafe(true).WithPlatform(Platform.AnyCpu);
+            var compOpts = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary).WithOptimizationLevel(OptimizationLevel.Release).WithAllowUnsafe(true).WithPlatform(Platform.AnyCpu);
 
             var compilation = CSharpCompilation.Create(Guid.NewGuid().ToString(), options: compOpts, references: References).AddSyntaxTrees(scriptSyntaxTree);
 


### PR DESCRIPTION
Viewing IL for an assembly compiled in debug mode isn't particularly useful. Let's compile the assembly with optimizations instead.