### PR TITLE
Fix unit tests

### DIFF
--- a/CSDiscordService.Tests/EvalTests.cs
+++ b/CSDiscordService.Tests/EvalTests.cs
@@ -21,6 +21,8 @@ namespace CSDiscordService.Tests
             
         public EvalTests(ITestOutputHelper outputHelper)
         {
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", EnvironmentName.Development);
+
             var host = WebHost.CreateDefaultBuilder()
                 //.UseApplicationInsights()
                 .UseStartup<Startup>();
@@ -222,7 +224,7 @@ namespace CSDiscordService.Tests
             Assert.Equal(HttpStatusCode.OK, statusCode);
             Assert.Equal(expr, result.Code);
             Assert.Null(result.ReturnValue);
-            Assert.Equal("string", result.ReturnTypeName);
+            Assert.Null(result.ReturnTypeName);
         }
 
         [Fact]


### PR DESCRIPTION
Set the eval tests to run as "Development" instead of "Production" so that the environment didn't exit in the middle of handling a request.

Relevant: https://github.com/discord-csharp/CSDiscord/blob/master/CSDiscordService/Startup.cs#L70-L82