### PR TITLE
Use a StreamReader instead of TextReader to avoid synchronous IO

### DIFF
--- a/CSDiscordService/PlainTextInputFormatter.cs
+++ b/CSDiscordService/PlainTextInputFormatter.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Text;
+using System.IO;
 
 namespace CSDiscordService
 {
@@ -31,14 +32,20 @@ namespace CSDiscordService
 
         public override async Task<InputFormatterResult> ReadAsync(InputFormatterContext context)
         {
-            var reader = context.ReaderFactory.Invoke(context.HttpContext.Request.Body, Encoding.UTF8);
-            return await InputFormatterResult.SuccessAsync(await reader.ReadToEndAsync());
+            using (var reader = new StreamReader(context.HttpContext.Request.Body, Encoding.UTF8))
+            {
+                var content = await reader.ReadToEndAsync();
+                return await InputFormatterResult.SuccessAsync(content);
+            }
         }
 
         public override async Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context, Encoding encoding)
         {
-            var reader = context.ReaderFactory.Invoke(context.HttpContext.Request.Body, encoding);
-            return await InputFormatterResult.SuccessAsync(await reader.ReadToEndAsync());
+            using (var reader = new StreamReader(context.HttpContext.Request.Body, encoding))
+            {
+                var content = await reader.ReadToEndAsync();
+                return await InputFormatterResult.SuccessAsync(content);
+            }
         }
     }
 }

--- a/CSDiscordService/Startup.cs
+++ b/CSDiscordService/Startup.cs
@@ -10,6 +10,7 @@ using CSDiscordService.Eval;
 using System;
 using System.Threading.Tasks;
 using System.Threading;
+using Microsoft.AspNetCore.Http.Features;
 
 namespace CSDiscordService
 {
@@ -79,6 +80,14 @@ namespace CSDiscordService
                         Environment.Exit(0);
                         return Task.CompletedTask;
                     });
+                }
+
+                //Workaround for https://github.com/aspnet/AspNetCore/issues/7644 , specifically https://github.com/aspnet/AspNetCore/issues/8302
+                //which will be properly resolved when 3.0 releases I assume
+                var syncIOFeature = context.Features.Get<IHttpBodyControlFeature>();
+                if (syncIOFeature != null)
+                {
+                    syncIOFeature.AllowSynchronousIO = true;
                 }
 
                 await next();


### PR DESCRIPTION
Requests throw an exception on recent 3.0 SDK versions otherwise, see https://github.com/aspnet/AspNetCore/issues/7644