### PR TITLE
Add converter to serialize ValueTuples

### DIFF
--- a/CSDiscordService.Tests/EvalTests.cs
+++ b/CSDiscordService.Tests/EvalTests.cs
@@ -52,8 +52,9 @@ namespace CSDiscordService.Tests
                 new TypeJsonConverterFactory(),
                 new AssemblyJsonConverter(),
                 new ModuleJsonConverter(),
-                 new AssemblyJsonConverterFactory(),
-                 new DirectoryInfoJsonConverter()
+                new AssemblyJsonConverterFactory(),
+                new DirectoryInfoJsonConverter(),
+                new ValueTupleConverterFactory(),
             }
 
         };
@@ -100,7 +101,7 @@ namespace CSDiscordService.Tests
                 (code: @"new DirectoryInfo(""app"")", expected: new DirectoryInfo("app").FullName)
             };
 
-            foreach(var (code, expected) in tests)
+            foreach (var (code, expected) in tests)
             {
                 var (result, statusCode) = await Execute(code);
                 var res = result.ReturnValue as JsonElement?;

--- a/CSDiscordService/Infrastructure/JsonFormatters/ValueTupleConverter.cs
+++ b/CSDiscordService/Infrastructure/JsonFormatters/ValueTupleConverter.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace CSDiscordService.Infrastructure.JsonFormatters
+{
+    public class ValueTupleConverterFactory : JsonConverterFactory
+    {
+        public override bool CanConvert(Type typeToConvert)
+            => typeToConvert.Namespace == nameof(System)
+            && typeToConvert.IsValueType
+            && typeof(ITuple).IsAssignableFrom(typeToConvert);
+
+        public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+            => new ValueTupleConverter();
+
+        private class ValueTupleConverter : JsonConverter<object>
+        {
+            public override object Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+                => throw new NotSupportedException();
+
+            public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
+            {
+                var tuple = (ITuple)value;
+
+                writer.WriteStartObject();
+
+                for (var i = 0; i < tuple.Length; i++)
+                {
+                    writer.WritePropertyName($"Item{i + 1}");
+                    JsonSerializer.Serialize(writer, tuple[i], options);
+                }
+
+                writer.WriteEndObject();
+            }
+        }
+    }
+}

--- a/CSDiscordService/Infrastructure/JsonFormatters/ValueTupleConverter.cs
+++ b/CSDiscordService/Infrastructure/JsonFormatters/ValueTupleConverter.cs
@@ -10,6 +10,7 @@ namespace CSDiscordService.Infrastructure.JsonFormatters
         public override bool CanConvert(Type typeToConvert)
             => typeToConvert.Namespace == nameof(System)
             && typeToConvert.IsValueType
+            && typeToConvert.Name.StartsWith("ValueTuple")
             && typeof(ITuple).IsAssignableFrom(typeToConvert);
 
         public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)

--- a/CSDiscordService/Startup.cs
+++ b/CSDiscordService/Startup.cs
@@ -45,7 +45,8 @@ namespace CSDiscordService
                 PropertyNameCaseInsensitive = true,
                 Converters = { new TimeSpanConverter(),  new TypeJsonConverter(), new TypeInfoJsonConverter(),
                     new RuntimeTypeHandleJsonConverter(), new TypeJsonConverterFactory(), new AssemblyJsonConverter(),
-                    new ModuleJsonConverter(), new AssemblyJsonConverterFactory(), new DirectoryInfoJsonConverter()}
+                    new ModuleJsonConverter(), new AssemblyJsonConverterFactory(), new DirectoryInfoJsonConverter(),
+                    new ValueTupleConverterFactory(), }
             };
 
             services.AddControllers(o =>
@@ -66,6 +67,7 @@ namespace CSDiscordService
                 o.JsonSerializerOptions.Converters.Add(new ModuleJsonConverter());
                 o.JsonSerializerOptions.Converters.Add(new AssemblyJsonConverterFactory());
                 o.JsonSerializerOptions.Converters.Add(new DirectoryInfoJsonConverter());
+                o.JsonSerializerOptions.Converters.Add(new ValueTupleConverterFactory());
             })
             .SetCompatibilityVersion(CompatibilityVersion.Version_3_0);
             services.AddSingleton(jsonOptions);


### PR DESCRIPTION
Uses a factory, because we only want to match on `ValueTuple` (regular `Tuple` also implements `ITuple`).

`ValueTupleConverter` implements `JsonConverter<object>` instead of `JsonConverter<ITuple>`, because I was getting an exception otherwise:

"An exception occurred when serializing the response: ArgumentException: GenericArguments[1], 'System.Object', on 'System.Text.Json.Serialization.JsonPropertyInfoNotNullableContravariant`4[TClass,TDeclaredProperty,TRuntimeProperty,TConverter]' violates the constraint of type 'TDeclaredProperty'."

![image](https://user-images.githubusercontent.com/2829282/71598801-5e531700-2b16-11ea-9e8e-97c9a0419497.png)
