### PR TITLE
Bugfix: nuget dependencies were not loaded in the AssemblyLoadContext which made some dll, that exposed a type of a dependency, not working.

### DIFF
--- a/CSDiscordService.Tests/EvalTests.cs
+++ b/CSDiscordService.Tests/EvalTests.cs
@@ -190,6 +190,15 @@ namespace CSDiscordService.Tests
         }
 
         [Fact]
+        public async Task Eval_LoadDLLThatExposesTypeOfADependency()
+		{
+            var expr = "#nuget CK.ActivityMonitor\nvar m = new ActivityMonitor();";
+            var (_, statusCode) = await Execute(expr);
+
+            Assert.Equal(HttpStatusCode.OK, statusCode);
+        }
+
+        [Fact]
         public async Task Eval_FaultyDirectiveFailsGracefully()
         {
             var expr = "#nuget asdasd asdasd asda\nConsole.WriteLine(\"foo\");";

--- a/CSDiscordService/Eval/NugetdirectiveProcessor.cs
+++ b/CSDiscordService/Eval/NugetdirectiveProcessor.cs
@@ -115,7 +115,7 @@ namespace CSDiscordService.Eval
 
             foreach (var path in libraries)
             {
-                var assembly = Assembly.LoadFile(path);
+                var assembly = Assembly.LoadFrom(path);
                 if (context.TryAddReferenceAssembly(assembly))
                 {
                     foreach (var ns in assembly.GetTypes().Select(a => a.Namespace).Distinct())


### PR DESCRIPTION
I added a test that use this nuget package: https://www.nuget.org/packages/CK.ActivityMonitor/
because this nuget package was failing in the REPL.